### PR TITLE
关于子进程运行时机问题

### DIFF
--- a/webbench.c
+++ b/webbench.c
@@ -24,7 +24,7 @@
 #include <time.h>
 #include <signal.h>
 
-#define MAX_SIZE 1024*1024
+#define MAX_SIZE 3*1024*1024
 /* values */
 volatile int timerexpired=0;
 int speed=0;

--- a/webbench.c
+++ b/webbench.c
@@ -24,7 +24,7 @@
 #include <time.h>
 #include <signal.h>
 
-#define MAX_SIZE 3*1024*1024
+#define MAX_SIZE 50*1024
 /* values */
 volatile int timerexpired=0;
 int speed=0;
@@ -337,7 +337,7 @@ static int bench(void)
 	   }
         /*record child pid*/
         pids[i]=pid;
-        sleep(1);
+        usleep(500);
         /*after fork last child, start all clients*/
         if(i == clients - 1)
         {


### PR DESCRIPTION
你好，我看了WebBench的代码，发现父进程在fork子进程后，只是让子进程sleep了一秒，然后就运行子进程。如果client的数量比较大的话，可能在1s内有的子进程还没有fork出来，前面的子进程就已经运行了，这样会导致测试的并发进程数和输入的参数不一致，不知道我的想法有没有错误。
