### PR TITLE
Create CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.10)
+#set(CMAKE_VERBOSE_MAKEFILE ON)
+project(webbench_1_5)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CFLAGS "-Wall -ggdb -W -O")
+set(CC "gcc")
+set(VERSION "1.5")
+
+
+# $ make
+add_library(Socket socket.c)
+add_executable(webbench webbench.c)
+link_libraries(Socket)
+
+
+# $ make install
+install(TARGETS webbench DESTINATION bin)
+install(FILES webbench.1 DESTINATION man/man1
+        PERMISSIONS WORLD_READ OWNER_WRITE)
+install(DIRECTORY DESTINATION share/doc/webbench)
+install(FILES debian/copyright debian/changelog DESTINATION share/doc/webbench
+        PERMISSIONS WORLD_READ OWNER_WRITE)
+
+
+# $ make clean-all
+set(FILE_PATHS
+        ${CMAKE_INSTALL_PREFIX}/bin/webbench
+        ${CMAKE_INSTALL_PREFIX}/man/man1/webbench.1
+        ${CMAKE_INSTALL_PREFIX}/share/doc/webbench/copyright
+        ${CMAKE_INSTALL_PREFIX}/share/doc/webbench/changelog
+)
+add_custom_target(clean-all)
+foreach(file_path ${FILE_PATHS})
+    add_custom_command(TARGET clean-all
+                POST_BUILD
+                COMMAND /bin/sh -c "\
+               if test -f '${file_path}' ;\
+               then \
+                    rm -rf ${file_path} ;\
+                    echo '${file_path} is been deleted' ;\
+               fi;"
+                VERBATIM
+            )
+endforeach()
+
+
+
+
+
+


### PR DESCRIPTION
### 添加 CMakeLists.txt ###
- 利于 CLion 用户的使用
CLion 使用 CMake 作为项目管理器, CMake 使用 CMakeLists.txt 编译输出 Makefile 文件,
没有 CMakeLists.txt ,CLion 就无法正常打开对应的项目
- 不改变原有项目结构 
CMakeLists.txt 在原有 Makefile 基础上进行修改 
- 相应指令
编译之后,使用 `make install` 进行二进制文件的安装. 
由于 CMake 没有对应的`make clean` 指令,因此使用 CMake 中的 `add_custom_target`新建指令
`make install`安装之后,使用 `make clean-all`进行二进制文件的卸载
